### PR TITLE
Add OBD-II, web dashboard, Claude AI assistant, and media player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "carconnect-pro",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "better-sqlite3": "^11.7.0",
         "express": "^4.21.0",
         "joi": "^17.13.0",
+        "serialport": "^13.0.0",
         "uuid": "^10.0.0",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "ws": "^8.19.0"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
@@ -22,6 +25,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -463,6 +486,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1174,6 +1206,245 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-13.0.0.tgz",
+      "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "@serialport/parser-readline": "12.0.0",
+        "debug": "4.4.0",
+        "node-addon-api": "8.3.0",
+        "node-gyp-build": "4.8.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
+      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
+      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/parser-delimiter": "12.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@serialport/parser-byte-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
+      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-cctalk": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
+      "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-delimiter": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
+      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-inter-byte-timeout": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
+      "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-packet-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
+      "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@serialport/parser-readline": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
+      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/parser-delimiter": "13.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-ready": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
+      "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-regex": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
+      "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-slip-encoder": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
+      "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-spacepacket": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
+      "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
+      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sideway/address": {
@@ -2207,7 +2478,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4280,6 +4550,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4643,6 +4926,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -5443,6 +5746,51 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/serialport": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
+      "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "13.0.0",
+        "@serialport/parser-byte-length": "13.0.0",
+        "@serialport/parser-cctalk": "13.0.0",
+        "@serialport/parser-delimiter": "13.0.0",
+        "@serialport/parser-inter-byte-timeout": "13.0.0",
+        "@serialport/parser-packet-length": "13.0.0",
+        "@serialport/parser-readline": "13.0.0",
+        "@serialport/parser-ready": "13.0.0",
+        "@serialport/parser-regex": "13.0.0",
+        "@serialport/parser-slip-encoder": "13.0.0",
+        "@serialport/parser-spacepacket": "13.0.0",
+        "@serialport/stream": "13.0.0",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/serialport/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
@@ -5960,6 +6308,12 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6238,6 +6592,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
     "format": "prettier --write 'src/**/*.js' 'tests/**/*.js'"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "better-sqlite3": "^11.7.0",
     "express": "^4.21.0",
     "joi": "^17.13.0",
+    "serialport": "^13.0.0",
     "uuid": "^10.0.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,1347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<title>CarConnect Pro</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Rajdhani:wght@300;400;500;600;700&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0a0e17;
+  --surface: #111827;
+  --surface-2: #1a2235;
+  --border: #1e293b;
+  --accent: #f97316;
+  --accent-glow: rgba(249, 115, 22, 0.3);
+  --cyan: #06b6d4;
+  --cyan-glow: rgba(6, 182, 212, 0.25);
+  --green: #22c55e;
+  --red: #ef4444;
+  --yellow: #eab308;
+  --text: #e2e8f0;
+  --text-dim: #64748b;
+  --gauge-track: #1e293b;
+}
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Rajdhani', sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  background:
+    radial-gradient(ellipse at 20% 50%, rgba(249, 115, 22, 0.04) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 50%, rgba(6, 182, 212, 0.04) 0%, transparent 50%),
+    var(--bg);
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto 1fr auto;
+  gap: 8px;
+  padding: 8px;
+  height: 100vh;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+/* Header */
+.header {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.header h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  background: linear-gradient(135deg, var(--accent), var(--cyan));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.status-dots {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 4px;
+}
+
+.status-dot.green { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.status-dot.red { background: var(--red); box-shadow: 0 0 6px var(--red); }
+.status-dot.yellow { background: var(--yellow); box-shadow: 0 0 6px var(--yellow); }
+
+/* Panels */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent-glow), transparent);
+}
+
+.panel-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+/* Gauges Panel */
+.gauges-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.gauge-container {
+  position: relative;
+  width: 180px;
+  height: 180px;
+}
+
+.gauge-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.gauge-track {
+  fill: none;
+  stroke: var(--gauge-track);
+  stroke-width: 10;
+  stroke-linecap: round;
+}
+
+.gauge-fill {
+  fill: none;
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.3s ease;
+  filter: drop-shadow(0 0 4px currentColor);
+}
+
+.gauge-fill.speed { stroke: var(--accent); }
+.gauge-fill.rpm { stroke: var(--cyan); }
+
+.gauge-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+}
+
+.gauge-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 36px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.gauge-value.speed-val { color: var(--accent); }
+.gauge-value.rpm-val { color: var(--cyan); }
+
+.gauge-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.gear-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.gear-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 48px;
+  font-weight: 900;
+  color: var(--green);
+  text-shadow: 0 0 20px rgba(34, 197, 94, 0.4);
+  line-height: 1;
+}
+
+.gear-label {
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+/* Vehicle Info Panel */
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.info-card {
+  background: var(--surface-2);
+  border-radius: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+}
+
+.info-card-label {
+  font-size: 10px;
+  color: var(--text-dim);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.info-card-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.info-card-value.warn { color: var(--yellow); }
+.info-card-value.danger { color: var(--red); }
+.info-card-value.ok { color: var(--green); }
+
+.info-card-unit {
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-left: 2px;
+}
+
+/* Audio Panel */
+.audio-sources {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.source-btn {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  padding: 8px 12px;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 48px;
+  text-align: center;
+}
+
+.source-btn:active { transform: scale(0.95); }
+.source-btn.active {
+  background: linear-gradient(135deg, var(--accent), #ea580c);
+  border-color: var(--accent);
+  color: white;
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.slider-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  min-width: 52px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.slider-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 13px;
+  min-width: 32px;
+  text-align: right;
+  color: var(--accent);
+}
+
+input[type="range"] {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--gauge-track);
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+/* Footer */
+.footer {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 6px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.footer-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dtc-badge {
+  background: var(--red);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dtc-badge.clear {
+  background: var(--green);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto auto auto;
+    overflow-y: auto;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  body { overflow: auto; }
+
+  .gauge-container { width: 140px; height: 140px; }
+  .gauge-value { font-size: 28px; }
+  .gear-value { font-size: 36px; }
+  .info-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  .gauges-panel { gap: 10px; }
+  .gauge-container { width: 110px; height: 110px; }
+  .gauge-value { font-size: 22px; }
+  .gear-value { font-size: 28px; }
+  .audio-sources { gap: 4px; }
+  .source-btn { padding: 6px 8px; font-size: 11px; }
+}
+
+/* Chat Panel */
+.chat-panel {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+  min-height: 80px;
+  max-height: 180px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.chat-msg {
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 1.4;
+  max-width: 85%;
+  word-wrap: break-word;
+}
+
+.chat-msg.user {
+  align-self: flex-end;
+  background: linear-gradient(135deg, var(--accent), #ea580c);
+  color: white;
+  border-bottom-right-radius: 3px;
+}
+
+.chat-msg.assistant {
+  align-self: flex-start;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-bottom-left-radius: 3px;
+}
+
+.chat-msg.system {
+  align-self: center;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input {
+  flex: 1;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 10px 14px;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.chat-input:focus { border-color: var(--accent); }
+.chat-input::placeholder { color: var(--text-dim); }
+
+.chat-btn {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  padding: 10px 14px;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+}
+
+.chat-btn:active { transform: scale(0.95); }
+.chat-btn.send { background: linear-gradient(135deg, var(--accent), #ea580c); color: white; border-color: var(--accent); }
+.chat-btn.listening { background: var(--red); color: white; border-color: var(--red); box-shadow: 0 0 12px rgba(239, 68, 68, 0.4); }
+.chat-btn.convo-active { background: var(--cyan); color: white; border-color: var(--cyan); box-shadow: 0 0 12px var(--cyan-glow); }
+.chat-btn:disabled { opacity: 0.4; cursor: default; }
+
+.tool-badge {
+  display: inline-block;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--surface);
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  margin-right: 4px;
+  margin-bottom: 2px;
+  letter-spacing: 0.5px;
+}
+
+@keyframes micPulse {
+  0%, 100% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.4); }
+  50% { box-shadow: 0 0 24px rgba(239, 68, 68, 0.7); }
+}
+.chat-btn.listening { animation: micPulse 1.5s ease-in-out infinite; }
+
+.chat-thinking {
+  display: inline-flex;
+  gap: 4px;
+  padding: 8px 16px;
+}
+.chat-thinking span {
+  width: 6px; height: 6px;
+  background: var(--text-dim);
+  border-radius: 50%;
+  animation: chatDot 1.2s ease-in-out infinite;
+}
+.chat-thinking span:nth-child(2) { animation-delay: 0.15s; }
+.chat-thinking span:nth-child(3) { animation-delay: 0.3s; }
+@keyframes chatDot { 0%, 60%, 100% { transform: translateY(0); } 30% { transform: translateY(-6px); } }
+
+/* Media Panel */
+.media-panel {
+  grid-column: 1 / -1;
+  display: none;
+}
+
+.media-panel.active { display: block; }
+
+.media-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.media-services {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.service-btn {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  padding: 6px 12px;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.service-btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.service-btn:active { transform: scale(0.95); }
+
+.media-close {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--red);
+  padding: 6px 10px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.media-close:hover { border-color: var(--red); background: rgba(239, 68, 68, 0.1); }
+
+.media-frame-container {
+  width: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #000;
+  position: relative;
+}
+
+.media-frame-container iframe {
+  width: 100%;
+  height: 300px;
+  border: none;
+}
+
+.media-url-bar {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.media-url-input {
+  flex: 1;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 8px 12px;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 13px;
+  outline: none;
+}
+
+.media-url-input:focus { border-color: var(--cyan); }
+.media-url-input::placeholder { color: var(--text-dim); }
+
+.media-go-btn {
+  background: var(--cyan);
+  border: 1px solid var(--cyan);
+  border-radius: 6px;
+  color: white;
+  padding: 8px 14px;
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .media-frame-container iframe { height: 200px; }
+}
+
+/* Animations */
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+.reconnecting { animation: pulse 1.5s ease-in-out infinite; }
+</style>
+</head>
+<body>
+
+<div class="dashboard">
+  <!-- Header -->
+  <div class="header">
+    <h1>CARCONNECT PRO</h1>
+    <div class="status-dots">
+      <span><span class="status-dot" id="ws-dot"></span><span id="ws-label">--</span></span>
+      <span><span class="status-dot" id="obd-dot"></span>OBD: <span id="obd-mode">--</span></span>
+    </div>
+  </div>
+
+  <!-- Gauges -->
+  <div class="panel">
+    <div class="panel-title">Telemetry</div>
+    <div class="gauges-panel">
+      <div class="gauge-container">
+        <svg class="gauge-svg" viewBox="0 0 120 120">
+          <circle class="gauge-track" cx="60" cy="60" r="50" stroke-dasharray="235.6" stroke-dashoffset="59" />
+          <circle class="gauge-fill speed" id="speed-arc" cx="60" cy="60" r="50" stroke-dasharray="235.6" stroke-dashoffset="176.7" />
+        </svg>
+        <div class="gauge-center">
+          <div class="gauge-value speed-val" id="speed-val">0</div>
+          <div class="gauge-label">km/h</div>
+        </div>
+      </div>
+      <div class="gear-display">
+        <div class="gear-value" id="gear-val">P</div>
+        <div class="gear-label">Gear</div>
+      </div>
+      <div class="gauge-container">
+        <svg class="gauge-svg" viewBox="0 0 120 120">
+          <circle class="gauge-track" cx="60" cy="60" r="50" stroke-dasharray="235.6" stroke-dashoffset="59" />
+          <circle class="gauge-fill rpm" id="rpm-arc" cx="60" cy="60" r="50" stroke-dasharray="235.6" stroke-dashoffset="176.7" />
+        </svg>
+        <div class="gauge-center">
+          <div class="gauge-value rpm-val" id="rpm-val">0</div>
+          <div class="gauge-label">RPM</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Vehicle Info -->
+  <div class="panel">
+    <div class="panel-title">Vehicle</div>
+    <div class="info-grid">
+      <div class="info-card">
+        <div class="info-card-label">Coolant</div>
+        <div class="info-card-value ok" id="coolant-val">--<span class="info-card-unit">&deg;C</span></div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-label">Fuel</div>
+        <div class="info-card-value ok" id="fuel-val">--<span class="info-card-unit">%</span></div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-label">Throttle</div>
+        <div class="info-card-value" id="throttle-val">--<span class="info-card-unit">%</span></div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-label">Engine Load</div>
+        <div class="info-card-value" id="load-val">--<span class="info-card-unit">%</span></div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-label">Battery</div>
+        <div class="info-card-value ok" id="battery-val">--<span class="info-card-unit">V</span></div>
+      </div>
+      <div class="info-card">
+        <div class="info-card-label">Ignition</div>
+        <div class="info-card-value" id="ignition-val">--</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Audio Controls -->
+  <div class="panel" style="grid-column: 1 / -1;">
+    <div class="panel-title">Audio</div>
+    <div class="audio-sources" id="audio-sources"></div>
+    <div class="slider-group">
+      <div class="slider-row">
+        <span class="slider-label">Volume</span>
+        <input type="range" id="vol-slider" min="0" max="100" value="50">
+        <span class="slider-value" id="vol-val">50</span>
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">Bass</span>
+        <input type="range" id="bass-slider" min="-10" max="10" value="0">
+        <span class="slider-value" id="bass-val">0</span>
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">Treble</span>
+        <input type="range" id="treble-slider" min="-10" max="10" value="0">
+        <span class="slider-value" id="treble-val">0</span>
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">Balance</span>
+        <input type="range" id="balance-slider" min="-100" max="100" value="0">
+        <span class="slider-value" id="balance-val">0</span>
+      </div>
+      <div class="slider-row">
+        <span class="slider-label">Fade</span>
+        <input type="range" id="fade-slider" min="-100" max="100" value="0">
+        <span class="slider-value" id="fade-val">0</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Media Player -->
+  <div class="panel media-panel" id="media-panel">
+    <div class="media-header">
+      <div class="panel-title" style="margin-bottom:0;">Media</div>
+      <div class="media-services">
+        <button class="service-btn" onclick="openService('youtube')">YouTube</button>
+        <button class="service-btn" onclick="openService('primevideo')">Prime Video</button>
+        <button class="service-btn" onclick="openService('netflix')">Netflix</button>
+        <button class="service-btn" onclick="openService('disneyplus')">Disney+</button>
+        <button class="service-btn" onclick="openService('hbomax')">Max</button>
+        <button class="service-btn" onclick="openService('spotify')">Spotify</button>
+      </div>
+      <button class="media-close" id="media-close-btn" onclick="closeMedia()">&#x2715;</button>
+    </div>
+    <div class="media-frame-container">
+      <iframe id="media-frame" src="about:blank" allow="autoplay; encrypted-media; fullscreen" allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
+    </div>
+    <div class="media-url-bar">
+      <input class="media-url-input" id="media-url" type="text" placeholder="Paste a YouTube URL or search..." autocomplete="off">
+      <button class="media-go-btn" onclick="loadMediaUrl()">Go</button>
+    </div>
+  </div>
+
+  <!-- Claude Chat -->
+  <div class="panel chat-panel">
+    <div class="panel-title">Claude Assistant</div>
+    <div class="chat-messages" id="chat-messages">
+      <div class="chat-msg system" id="chat-status">Checking availability...</div>
+    </div>
+    <div class="chat-input-row">
+      <button class="chat-btn" id="convo-btn" title="Conversation mode — hands-free">&#x1F504;</button>
+      <button class="chat-btn" id="mic-btn" title="Push to talk">&#x1F3A4;</button>
+      <input class="chat-input" id="chat-input" type="text" placeholder="Ask me anything..." autocomplete="off">
+      <button class="chat-btn send" id="send-btn" title="Send">&#x27A4;</button>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <div class="footer">
+    <div class="footer-item">
+      <span class="dtc-badge clear" id="dtc-badge">NO FAULTS</span>
+    </div>
+    <div class="footer-item" style="margin-left: auto;">
+      <span id="clock"></span>
+    </div>
+  </div>
+</div>
+
+<script>
+(function() {
+  'use strict';
+
+  // --- DOM refs ---
+  const speedVal = document.getElementById('speed-val');
+  const speedArc = document.getElementById('speed-arc');
+  const rpmVal = document.getElementById('rpm-val');
+  const rpmArc = document.getElementById('rpm-arc');
+  const gearVal = document.getElementById('gear-val');
+  const coolantVal = document.getElementById('coolant-val');
+  const fuelVal = document.getElementById('fuel-val');
+  const throttleVal = document.getElementById('throttle-val');
+  const loadVal = document.getElementById('load-val');
+  const batteryVal = document.getElementById('battery-val');
+  const ignitionVal = document.getElementById('ignition-val');
+  const wsDot = document.getElementById('ws-dot');
+  const wsLabel = document.getElementById('ws-label');
+  const obdDot = document.getElementById('obd-dot');
+  const obdMode = document.getElementById('obd-mode');
+  const audioSourcesEl = document.getElementById('audio-sources');
+  const dtcBadge = document.getElementById('dtc-badge');
+  const clockEl = document.getElementById('clock');
+
+  const sliders = {
+    volume: { slider: document.getElementById('vol-slider'), display: document.getElementById('vol-val') },
+    bass: { slider: document.getElementById('bass-slider'), display: document.getElementById('bass-val') },
+    treble: { slider: document.getElementById('treble-slider'), display: document.getElementById('treble-val') },
+    balance: { slider: document.getElementById('balance-slider'), display: document.getElementById('balance-val') },
+    fade: { slider: document.getElementById('fade-slider'), display: document.getElementById('fade-val') },
+  };
+
+  // Gauge constants: 270-degree arc
+  const ARC_LENGTH = 176.7; // 3/4 of circumference (235.6 * 0.75)
+  const MAX_SPEED = 220;
+  const MAX_RPM = 7000;
+
+  let ws = null;
+  let reconnectDelay = 1000;
+  let activeSource = 'radio';
+  let audioSources = [];
+  let sliderTimeout = null;
+
+  // --- WebSocket ---
+  function connectWS() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(proto + '//' + location.host);
+
+    ws.onopen = function() {
+      reconnectDelay = 1000;
+      setConnectionStatus('connected');
+    };
+
+    ws.onclose = function() {
+      setConnectionStatus('disconnected');
+      setTimeout(connectWS, reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+    };
+
+    ws.onerror = function() {
+      ws.close();
+    };
+
+    ws.onmessage = function(evt) {
+      try {
+        var msg = JSON.parse(evt.data);
+        handleMessage(msg);
+      } catch(e) { /* ignore */ }
+    };
+  }
+
+  function setConnectionStatus(status) {
+    if (status === 'connected') {
+      wsDot.className = 'status-dot green';
+      wsLabel.textContent = 'Live';
+    } else {
+      wsDot.className = 'status-dot red';
+      wsLabel.textContent = 'Offline';
+    }
+  }
+
+  function handleMessage(msg) {
+    switch(msg.type) {
+      case 'init':
+        if (msg.data.obd) updateVehicleData(msg.data.obd);
+        if (msg.data.obdConnection) updateOBDStatus(msg.data.obdConnection);
+        if (msg.data.audio) {
+          audioSources = msg.data.audio.sources;
+          renderAudioSources();
+          updateAudioControls(msg.data.audio.controls);
+        }
+        if (msg.data.vehicle) updateVehicleInfo(msg.data.vehicle);
+        break;
+      case 'vehicleData':
+        updateVehicleData(msg.data);
+        break;
+      case 'audioState':
+        activeSource = msg.data.currentSource;
+        renderAudioSources();
+        break;
+      case 'audioControls':
+        updateAudioControls(msg.data.controls);
+        break;
+      case 'obdMode':
+        updateOBDStatus({ mode: msg.data.mode, connected: true });
+        break;
+    }
+  }
+
+  // --- Gauge updates ---
+  function updateGauge(arcEl, valueEl, value, max) {
+    var pct = Math.min(value / max, 1);
+    var offset = ARC_LENGTH - (pct * ARC_LENGTH);
+    arcEl.style.strokeDashoffset = offset;
+    valueEl.textContent = Math.round(value);
+  }
+
+  function updateVehicleData(data) {
+    if (data.speed !== undefined) updateGauge(speedArc, speedVal, data.speed, MAX_SPEED);
+    if (data.rpm !== undefined) updateGauge(rpmArc, rpmVal, data.rpm, MAX_RPM);
+    if (data.coolantTemp !== undefined) {
+      coolantVal.innerHTML = Math.round(data.coolantTemp) + '<span class="info-card-unit">&deg;C</span>';
+      coolantVal.className = 'info-card-value ' + (data.coolantTemp > 105 ? 'danger' : data.coolantTemp > 95 ? 'warn' : 'ok');
+    }
+    if (data.fuelLevel !== undefined) {
+      fuelVal.innerHTML = Math.round(data.fuelLevel) + '<span class="info-card-unit">%</span>';
+      fuelVal.className = 'info-card-value ' + (data.fuelLevel < 10 ? 'danger' : data.fuelLevel < 20 ? 'warn' : 'ok');
+    }
+    if (data.throttle !== undefined) {
+      throttleVal.innerHTML = Math.round(data.throttle) + '<span class="info-card-unit">%</span>';
+    }
+    if (data.engineLoad !== undefined) {
+      loadVal.innerHTML = Math.round(data.engineLoad) + '<span class="info-card-unit">%</span>';
+    }
+  }
+
+  function updateVehicleInfo(data) {
+    if (data.batteryVoltage !== undefined) {
+      batteryVal.innerHTML = data.batteryVoltage.toFixed(1) + '<span class="info-card-unit">V</span>';
+      batteryVal.className = 'info-card-value ' + (data.batteryVoltage < 11.5 ? 'danger' : data.batteryVoltage < 12 ? 'warn' : 'ok');
+    }
+    if (data.gear !== undefined) {
+      var gearMap = { park: 'P', reverse: 'R', neutral: 'N', drive: 'D', sport: 'S' };
+      gearVal.textContent = gearMap[data.gear] || data.gear;
+    }
+    if (data.ignition !== undefined || data.ignitionState !== undefined) {
+      var ig = data.ignitionState || (data.ignition ? 'on' : 'off');
+      ignitionVal.textContent = ig.toUpperCase();
+      ignitionVal.className = 'info-card-value ' + (ig === 'on' || ig === 'running' ? 'ok' : '');
+    }
+  }
+
+  function updateOBDStatus(info) {
+    if (info.mode === 'elm327') {
+      obdDot.className = 'status-dot green';
+      obdMode.textContent = 'ELM327';
+    } else if (info.mode === 'simulation') {
+      obdDot.className = 'status-dot yellow';
+      obdMode.textContent = 'SIM';
+    } else {
+      obdDot.className = 'status-dot red';
+      obdMode.textContent = '--';
+    }
+  }
+
+  // --- Audio ---
+  function renderAudioSources() {
+    audioSourcesEl.innerHTML = '';
+    var sources = audioSources.length ? audioSources : [
+      {id:'radio',name:'Radio'},{id:'bluetooth',name:'BT'},
+      {id:'usb',name:'USB'},{id:'aux',name:'AUX'},
+      {id:'android_auto',name:'Android'},{id:'apple_carplay',name:'CarPlay'}
+    ];
+    sources.forEach(function(src) {
+      var btn = document.createElement('button');
+      btn.className = 'source-btn' + (src.id === activeSource ? ' active' : '');
+      btn.textContent = src.name;
+      btn.onclick = function() { switchSource(src.id); };
+      audioSourcesEl.appendChild(btn);
+    });
+  }
+
+  function switchSource(sourceId) {
+    fetch('/api/v1/audio/source', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sourceId: sourceId, fadeTime: 100 }),
+    }).then(function(r) { return r.json(); }).then(function(data) {
+      if (data.success) {
+        activeSource = data.data.currentSource;
+        renderAudioSources();
+      }
+    }).catch(function() {});
+  }
+
+  function updateAudioControls(controls) {
+    if (!controls) return;
+    Object.keys(controls).forEach(function(key) {
+      var s = sliders[key];
+      if (s) {
+        s.slider.value = controls[key];
+        s.display.textContent = controls[key];
+      }
+    });
+  }
+
+  function sendControlUpdate(key, value) {
+    clearTimeout(sliderTimeout);
+    sliderTimeout = setTimeout(function() {
+      var body = {};
+      body[key] = parseInt(value, 10);
+      fetch('/api/v1/audio/control', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }).catch(function() {});
+    }, 50);
+  }
+
+  // Bind sliders
+  Object.keys(sliders).forEach(function(key) {
+    var s = sliders[key];
+    s.slider.addEventListener('input', function() {
+      s.display.textContent = s.slider.value;
+      sendControlUpdate(key, s.slider.value);
+    });
+  });
+
+  // --- Clock ---
+  function updateClock() {
+    var now = new Date();
+    clockEl.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  setInterval(updateClock, 1000);
+  updateClock();
+
+  // --- Init ---
+  // Load initial data via REST, then connect WebSocket for live updates
+  fetch('/api/v1/audio/sources').then(function(r) { return r.json(); }).then(function(data) {
+    if (data.data && data.data.sources) {
+      audioSources = data.data.sources;
+      activeSource = data.data.activeSource || 'radio';
+      renderAudioSources();
+    }
+  }).catch(function() { renderAudioSources(); });
+
+  fetch('/api/v1/audio/controls').then(function(r) { return r.json(); }).then(function(data) {
+    if (data.data) updateAudioControls(data.data);
+  }).catch(function() {});
+
+  fetch('/api/v1/vehicle/state').then(function(r) { return r.json(); }).then(function(data) {
+    if (data.data) {
+      updateVehicleData(data.data);
+      updateVehicleInfo(data.data);
+    }
+  }).catch(function() {});
+
+  fetch('/api/v1/vehicle/obd').then(function(r) { return r.json(); }).then(function(data) {
+    if (data.data) updateOBDStatus(data.data);
+  }).catch(function() {});
+
+  connectWS();
+  setConnectionStatus('disconnected');
+
+  // --- Media Player ---
+  var mediaPanel = document.getElementById('media-panel');
+  var mediaFrame = document.getElementById('media-frame');
+  var mediaUrlInput = document.getElementById('media-url');
+
+  var serviceUrls = {
+    youtube: 'https://m.youtube.com',
+    primevideo: 'https://www.primevideo.com',
+    netflix: 'https://www.netflix.com',
+    disneyplus: 'https://www.disneyplus.com',
+    hbomax: 'https://play.max.com',
+    spotify: 'https://open.spotify.com',
+  };
+
+  window.openService = function(name) {
+    var url = serviceUrls[name];
+    if (url) {
+      mediaFrame.src = url;
+      mediaPanel.classList.add('active');
+    }
+  };
+
+  window.closeMedia = function() {
+    mediaFrame.src = 'about:blank';
+    mediaPanel.classList.remove('active');
+  };
+
+  window.loadMediaUrl = function() {
+    var val = mediaUrlInput.value.trim();
+    if (!val) return;
+
+    // Check if it's a YouTube URL — try to embed it
+    var ytMatch = val.match(/(?:v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    if (ytMatch) {
+      mediaFrame.src = 'https://www.youtube.com/embed/' + ytMatch[1] + '?autoplay=1';
+      mediaPanel.classList.add('active');
+      mediaUrlInput.value = '';
+      return;
+    }
+
+    // Check if it looks like a search query (no dots/slashes)
+    if (!val.includes('.') && !val.includes('/')) {
+      mediaFrame.src = 'https://m.youtube.com/results?search_query=' + encodeURIComponent(val);
+      mediaPanel.classList.add('active');
+      mediaUrlInput.value = '';
+      return;
+    }
+
+    // Otherwise treat as URL
+    if (!val.startsWith('http')) val = 'https://' + val;
+    mediaFrame.src = val;
+    mediaPanel.classList.add('active');
+    mediaUrlInput.value = '';
+  };
+
+  mediaUrlInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') window.loadMediaUrl();
+  });
+
+  function handleMediaCommand(cmd) {
+    if (!cmd || !cmd.action) return;
+    if (cmd.action === 'open_url' && cmd.url) {
+      mediaFrame.src = cmd.url;
+      mediaPanel.classList.add('active');
+    } else if (cmd.action === 'embed_youtube' && cmd.videoId) {
+      mediaFrame.src = 'https://www.youtube.com/embed/' + cmd.videoId + '?autoplay=1';
+      mediaPanel.classList.add('active');
+    } else if (cmd.action === 'close_media') {
+      window.closeMedia();
+    }
+  }
+
+  // --- Claude Chat with MCP tools + continuous conversation ---
+  var chatMessages = document.getElementById('chat-messages');
+  var chatInput = document.getElementById('chat-input');
+  var sendBtn = document.getElementById('send-btn');
+  var micBtn = document.getElementById('mic-btn');
+  var convoBtn = document.getElementById('convo-btn');
+  var chatStatus = document.getElementById('chat-status');
+  var chatAvailable = false;
+  var chatSending = false;
+  var convoMode = false; // continuous conversation mode
+
+  // Speech recognition
+  var SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  var recognition = null;
+  var isListening = false;
+
+  if (SpeechRecognition) {
+    recognition = new SpeechRecognition();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.lang = 'en-US';
+
+    recognition.onresult = function(event) {
+      var transcript = event.results[0][0].transcript;
+      chatInput.value = transcript;
+      isListening = false;
+      micBtn.classList.remove('listening');
+      micBtn.innerHTML = '&#x1F3A4;';
+      sendChatMessage(transcript);
+    };
+
+    recognition.onerror = function() { stopListening(); };
+    recognition.onend = function() {
+      // Only update UI, don't restart — that's handled after speech finishes
+      isListening = false;
+      micBtn.classList.remove('listening');
+      micBtn.innerHTML = '&#x1F3A4;';
+    };
+  } else {
+    micBtn.style.display = 'none';
+    convoBtn.style.display = 'none';
+  }
+
+  function startListening() {
+    if (!recognition || isListening || chatSending) return;
+    isListening = true;
+    micBtn.classList.add('listening');
+    micBtn.innerHTML = '&#x23F9;';
+    try { recognition.start(); } catch(e) {}
+  }
+
+  function stopListening() {
+    if (!recognition) return;
+    isListening = false;
+    micBtn.classList.remove('listening');
+    micBtn.innerHTML = '&#x1F3A4;';
+    try { recognition.stop(); } catch(e) {}
+  }
+
+  // Toggle conversation mode
+  convoBtn.onclick = function() {
+    convoMode = !convoMode;
+    convoBtn.classList.toggle('convo-active', convoMode);
+    convoBtn.title = convoMode ? 'Conversation mode ON — tap to disable' : 'Conversation mode — hands-free';
+    if (convoMode && !chatSending) {
+      addChatMessage('system', 'Conversation mode ON — speak freely');
+      startListening();
+    } else if (!convoMode) {
+      stopListening();
+      window.speechSynthesis && window.speechSynthesis.cancel();
+    }
+  };
+
+  micBtn.onclick = function() {
+    if (isListening) { stopListening(); } else { startListening(); }
+  };
+
+  // Speech synthesis — after speaking, re-listen if in convo mode
+  function speakText(text, onDone) {
+    if (!window.speechSynthesis) { if (onDone) onDone(); return; }
+    window.speechSynthesis.cancel();
+    var utter = new SpeechSynthesisUtterance(text);
+    utter.rate = 1.05;
+    utter.pitch = 1.0;
+    utter.onend = function() { if (onDone) onDone(); };
+    utter.onerror = function() { if (onDone) onDone(); };
+    window.speechSynthesis.speak(utter);
+  }
+
+  function addChatMessage(role, text, toolsUsed) {
+    if (chatStatus && chatStatus.parentNode) {
+      chatStatus.parentNode.removeChild(chatStatus);
+      chatStatus = null;
+    }
+
+    var div = document.createElement('div');
+    div.className = 'chat-msg ' + role;
+
+    // Show tool badges for assistant messages
+    if (role === 'assistant' && toolsUsed && toolsUsed.length > 0) {
+      var badgeHtml = '';
+      var toolNames = { get_vehicle_status: 'Vehicle', get_diagnostics: 'DTCs', set_audio_source: 'Audio', set_volume: 'Volume', set_equalizer: 'EQ', get_audio_status: 'Audio', plan_route: 'Nav', get_navigation_status: 'GPS', list_profiles: 'Profiles', create_profile: 'Profile+', activate_profile: 'Profile', get_system_health: 'Health', get_performance_metrics: 'Perf', play_media: 'Media' };
+      var seen = {};
+      toolsUsed.forEach(function(t) {
+        if (!seen[t]) {
+          badgeHtml += '<span class="tool-badge">' + (toolNames[t] || t) + '</span>';
+          seen[t] = true;
+        }
+      });
+      div.innerHTML = badgeHtml + '<br>' + text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    } else {
+      div.textContent = text;
+    }
+
+    chatMessages.appendChild(div);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+    return div;
+  }
+
+  function showThinking() {
+    var div = document.createElement('div');
+    div.className = 'chat-msg assistant';
+    div.id = 'chat-thinking';
+    div.innerHTML = '<div class="chat-thinking"><span></span><span></span><span></span></div>';
+    chatMessages.appendChild(div);
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+  }
+
+  function removeThinking() {
+    var el = document.getElementById('chat-thinking');
+    if (el) el.parentNode.removeChild(el);
+  }
+
+  function onResponseDone() {
+    // In conversation mode, start listening again after Claude finishes speaking
+    if (convoMode && chatAvailable) {
+      setTimeout(function() { startListening(); }, 400);
+    }
+  }
+
+  function sendChatMessage(text) {
+    if (!text || !text.trim() || chatSending || !chatAvailable) return;
+
+    var msg = text.trim();
+    chatInput.value = '';
+    addChatMessage('user', msg);
+    showThinking();
+    chatSending = true;
+    sendBtn.disabled = true;
+
+    fetch('/api/v1/chat/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: msg }),
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      removeThinking();
+      chatSending = false;
+      sendBtn.disabled = false;
+      if (data.success && data.data.reply) {
+        addChatMessage('assistant', data.data.reply, data.data.toolsUsed);
+        // If tools changed audio, refresh the UI
+        if (data.data.toolsUsed && data.data.toolsUsed.some(function(t) {
+          return t.indexOf('audio') >= 0 || t.indexOf('volume') >= 0 || t.indexOf('equalizer') >= 0;
+        })) {
+          refreshAudioState();
+        }
+        // Handle media commands from Claude
+        if (data.data.mediaCommands) {
+          data.data.mediaCommands.forEach(handleMediaCommand);
+        }
+        speakText(data.data.reply, onResponseDone);
+      } else {
+        addChatMessage('system', data.error ? data.error.message : 'Failed to get response');
+        onResponseDone();
+      }
+    })
+    .catch(function() {
+      removeThinking();
+      chatSending = false;
+      sendBtn.disabled = false;
+      addChatMessage('system', 'Connection error');
+      onResponseDone();
+    });
+  }
+
+  function refreshAudioState() {
+    fetch('/api/v1/audio/sources').then(function(r) { return r.json(); }).then(function(data) {
+      if (data.data && data.data.sources) {
+        audioSources = data.data.sources;
+        activeSource = data.data.activeSource || 'radio';
+        renderAudioSources();
+      }
+    }).catch(function() {});
+    fetch('/api/v1/audio/controls').then(function(r) { return r.json(); }).then(function(data) {
+      if (data.data) updateAudioControls(data.data);
+    }).catch(function() {});
+  }
+
+  sendBtn.onclick = function() { sendChatMessage(chatInput.value); };
+  chatInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') { sendChatMessage(chatInput.value); }
+  });
+
+  // Check if Claude is available
+  fetch('/api/v1/chat/status').then(function(r) { return r.json(); }).then(function(data) {
+    chatAvailable = data.data && data.data.available;
+    if (chatAvailable) {
+      if (chatStatus) chatStatus.textContent = 'Ask about your car, or say "switch to bluetooth"';
+    } else {
+      if (chatStatus) chatStatus.textContent = 'Set ANTHROPIC_API_KEY to enable AI assistant';
+      chatInput.disabled = true;
+      sendBtn.disabled = true;
+      micBtn.disabled = true;
+      convoBtn.disabled = true;
+    }
+  }).catch(function() {
+    if (chatStatus) chatStatus.textContent = 'Chat unavailable';
+  });
+
+})();
+</script>
+
+</body>
+</html>

--- a/src/api/routes/audio.js
+++ b/src/api/routes/audio.js
@@ -15,6 +15,14 @@ const createAudioRouter = (audioService) => {
 
   router.get('/sources', (req, res) => controller.getSources(req, res));
 
+  router.get('/controls', (req, res) => {
+    res.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      data: service.getControls(),
+    });
+  });
+
   router.post(
     '/source',
     validateSwitchSource,

--- a/src/api/routes/chat.js
+++ b/src/api/routes/chat.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const express = require('express');
+const Joi = require('joi');
+
+const chatSchema = Joi.object({
+  message: Joi.string().min(1).max(2000).required(),
+  sessionId: Joi.string().optional(),
+});
+
+const createChatRouter = (claudeService) => {
+  const router = express.Router();
+
+  router.get('/status', (_req, res) => {
+    res.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      data: { available: claudeService.available },
+    });
+  });
+
+  router.post('/message', async (req, res) => {
+    const { error, value } = chatSchema.validate(req.body);
+    if (error) {
+      return res.status(400).json({
+        success: false,
+        timestamp: new Date().toISOString(),
+        error: { code: 'VALIDATION_ERROR', message: error.details[0].message },
+      });
+    }
+
+    const sessionId = value.sessionId || 'default';
+
+    try {
+      const result = await claudeService.chat(sessionId, value.message);
+      return res.json({
+        success: true,
+        timestamp: new Date().toISOString(),
+        data: {
+          reply: result.reply,
+          toolsUsed: result.toolsUsed || [],
+          mediaCommands: result.mediaCommands || [],
+          sessionId,
+        },
+      });
+    } catch (err) {
+      const status = err.message.includes('not configured') ? 503 : 500;
+      return res.status(status).json({
+        success: false,
+        timestamp: new Date().toISOString(),
+        error: { code: 'CHAT_ERROR', message: err.message },
+      });
+    }
+  });
+
+  router.delete('/session/:sessionId', (req, res) => {
+    claudeService.clearConversation(req.params.sessionId);
+    res.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  return router;
+};
+
+module.exports = createChatRouter;

--- a/src/drivers/elm327-driver.js
+++ b/src/drivers/elm327-driver.js
@@ -1,0 +1,357 @@
+'use strict';
+
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json(),
+  ),
+  defaultMeta: { service: 'elm327-driver' },
+  transports: [new winston.transports.Console({ silent: process.env.NODE_ENV === 'test' })],
+});
+
+let SerialPort;
+try {
+  SerialPort = require('serialport').SerialPort;
+} catch (_e) {
+  SerialPort = null;
+}
+
+const STATES = {
+  DISCONNECTED: 'disconnected',
+  CONNECTING: 'connecting',
+  INITIALIZING: 'initializing',
+  READY: 'ready',
+  ERROR: 'error',
+};
+
+const AT_INIT_COMMANDS = [
+  'ATZ',   // Reset
+  'ATE0',  // Echo off
+  'ATL0',  // Linefeeds off
+  'ATS0',  // Spaces off
+  'ATSP0', // Auto-detect protocol
+  'ATH0',  // Headers off
+];
+
+const PID_FORMULAS = {
+  '0C': { name: 'rpm', bytes: 2, formula: (a, b) => ((a * 256) + b) / 4 },
+  '0D': { name: 'speed', bytes: 1, formula: (a) => a },
+  '05': { name: 'coolantTemp', bytes: 1, formula: (a) => a - 40 },
+  '2F': { name: 'fuelLevel', bytes: 1, formula: (a) => (a / 255) * 100 },
+  '11': { name: 'throttle', bytes: 1, formula: (a) => (a / 255) * 100 },
+  '04': { name: 'engineLoad', bytes: 1, formula: (a) => (a / 255) * 100 },
+};
+
+const COMMAND_TIMEOUT = 2000;
+
+class Elm327Driver {
+  constructor(options = {}) {
+    this._portPath = options.serialPort || null;
+    this._baudRate = options.baudRate || 38400;
+    this._state = STATES.DISCONNECTED;
+    this._port = null;
+    this._responseBuffer = '';
+    this._pendingResolve = null;
+    this._pendingReject = null;
+    this._pendingTimer = null;
+    this._listeners = new Map();
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  static get STATES() {
+    return STATES;
+  }
+
+  static get PID_FORMULAS() {
+    return PID_FORMULAS;
+  }
+
+  on(event, fn) {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event).push(fn);
+  }
+
+  off(event, fn) {
+    const fns = this._listeners.get(event);
+    if (fns) {
+      this._listeners.set(event, fns.filter((f) => f !== fn));
+    }
+  }
+
+  _emit(event, data) {
+    const fns = this._listeners.get(event) || [];
+    for (const fn of fns) {
+      try {
+        fn(data);
+      } catch (e) {
+        logger.error('Event listener error', { event, error: e.message });
+      }
+    }
+  }
+
+  async connect() {
+    if (!SerialPort) {
+      throw new Error('serialport package not available');
+    }
+
+    const portPath = this._portPath || await this._autoDetectPort();
+    if (!portPath) {
+      throw new Error('No ELM327 device found');
+    }
+
+    this._state = STATES.CONNECTING;
+    this._emit('stateChange', this._state);
+
+    return new Promise((resolve, reject) => {
+      this._port = new SerialPort({
+        path: portPath,
+        baudRate: this._baudRate,
+        autoOpen: false,
+      });
+
+      this._port.on('data', (data) => this._onData(data));
+      this._port.on('error', (err) => this._onError(err));
+      this._port.on('close', () => this._onClose());
+
+      this._port.open((err) => {
+        if (err) {
+          this._state = STATES.ERROR;
+          this._emit('stateChange', this._state);
+          reject(new Error(`Failed to open port ${portPath}: ${err.message}`));
+        } else {
+          logger.info('Serial port opened', { port: portPath });
+          this._initialize().then(resolve).catch(reject);
+        }
+      });
+    });
+  }
+
+  async _initialize() {
+    this._state = STATES.INITIALIZING;
+    this._emit('stateChange', this._state);
+
+    for (const cmd of AT_INIT_COMMANDS) {
+      try {
+        await this._sendCommand(cmd);
+      } catch (err) {
+        if (cmd !== 'ATZ') {
+          logger.warn('AT init command failed', { cmd, error: err.message });
+        }
+      }
+    }
+
+    this._state = STATES.READY;
+    this._emit('stateChange', this._state);
+    logger.info('ELM327 initialized');
+  }
+
+  async requestPID(pid) {
+    if (this._state !== STATES.READY) {
+      throw new Error(`Cannot request PID in state: ${this._state}`);
+    }
+
+    const pidUpper = pid.toUpperCase();
+    const formula = PID_FORMULAS[pidUpper];
+    if (!formula) {
+      throw new Error(`Unknown PID: ${pid}`);
+    }
+
+    const response = await this._sendCommand(`01${pidUpper}`);
+    return this._parsePIDResponse(response, pidUpper);
+  }
+
+  async requestDTCs() {
+    if (this._state !== STATES.READY) {
+      throw new Error(`Cannot request DTCs in state: ${this._state}`);
+    }
+
+    const response = await this._sendCommand('03');
+    return this._parseDTCResponse(response);
+  }
+
+  async clearDTCs() {
+    if (this._state !== STATES.READY) {
+      throw new Error(`Cannot clear DTCs in state: ${this._state}`);
+    }
+
+    await this._sendCommand('04');
+    return true;
+  }
+
+  _sendCommand(cmd) {
+    return new Promise((resolve, reject) => {
+      if (this._pendingResolve) {
+        reject(new Error('Command already pending'));
+        return;
+      }
+
+      this._responseBuffer = '';
+      this._pendingResolve = resolve;
+      this._pendingReject = reject;
+
+      this._pendingTimer = setTimeout(() => {
+        const rej = this._pendingReject;
+        this._pendingResolve = null;
+        this._pendingReject = null;
+        this._pendingTimer = null;
+        if (rej) {
+          rej(new Error(`Command timeout: ${cmd}`));
+        }
+      }, COMMAND_TIMEOUT);
+
+      this._port.write(`${cmd}\r`, (err) => {
+        if (err) {
+          clearTimeout(this._pendingTimer);
+          this._pendingResolve = null;
+          this._pendingReject = null;
+          this._pendingTimer = null;
+          reject(new Error(`Write error: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  _onData(data) {
+    this._responseBuffer += data.toString();
+
+    if (this._responseBuffer.includes('>')) {
+      const response = this._responseBuffer
+        .replace(/>/g, '')
+        .replace(/\r/g, '')
+        .replace(/\n/g, '')
+        .trim();
+
+      if (this._pendingResolve) {
+        clearTimeout(this._pendingTimer);
+        const resolve = this._pendingResolve;
+        this._pendingResolve = null;
+        this._pendingReject = null;
+        this._pendingTimer = null;
+        resolve(response);
+      }
+    }
+  }
+
+  _onError(err) {
+    logger.error('Serial port error', { error: err.message });
+    this._state = STATES.ERROR;
+    this._emit('stateChange', this._state);
+    this._emit('error', err);
+  }
+
+  _onClose() {
+    logger.info('Serial port closed');
+    this._state = STATES.DISCONNECTED;
+    this._emit('stateChange', this._state);
+  }
+
+  _parsePIDResponse(response, pid) {
+    if (!response || response === 'NO DATA' || response === 'UNABLE TO CONNECT') {
+      return null;
+    }
+
+    const formula = PID_FORMULAS[pid];
+    if (!formula) {
+      return null;
+    }
+
+    // Response format: "41 0C 1A F8" (with spaces removed by ATS0: "410C1AF8")
+    const clean = response.replace(/\s/g, '');
+
+    // Find the response after the mode+pid echo (41XX)
+    const prefix = `41${pid}`;
+    const idx = clean.indexOf(prefix);
+    if (idx === -1) {
+      return null;
+    }
+
+    const dataHex = clean.substring(idx + prefix.length);
+    const bytes = [];
+    for (let i = 0; i < dataHex.length; i += 2) {
+      bytes.push(parseInt(dataHex.substring(i, i + 2), 16));
+    }
+
+    if (bytes.length < formula.bytes) {
+      return null;
+    }
+
+    const value = formula.formula(...bytes.slice(0, formula.bytes));
+    return { name: formula.name, value, raw: dataHex };
+  }
+
+  _parseDTCResponse(response) {
+    if (!response || response === 'NO DATA') {
+      return [];
+    }
+
+    const clean = response.replace(/\s/g, '');
+    if (!clean.startsWith('43')) {
+      return [];
+    }
+
+    const dtcData = clean.substring(2);
+    const codes = [];
+    const prefixes = { '0': 'P0', '1': 'P1', '2': 'P2', '3': 'P3', '4': 'C0', '5': 'C1', '6': 'C2', '7': 'C3', '8': 'B0', '9': 'B1', 'A': 'B2', 'B': 'B3', 'C': 'U0', 'D': 'U1', 'E': 'U2', 'F': 'U3' };
+
+    for (let i = 0; i < dtcData.length; i += 4) {
+      const chunk = dtcData.substring(i, i + 4);
+      if (chunk === '0000' || chunk.length < 4) {
+        continue;
+      }
+      const firstChar = chunk[0].toUpperCase();
+      const prefix = prefixes[firstChar] || 'P0';
+      const code = `${prefix}${chunk.substring(1)}`;
+      codes.push(code);
+    }
+
+    return codes;
+  }
+
+  async _autoDetectPort() {
+    if (!SerialPort || !SerialPort.list) {
+      return null;
+    }
+
+    try {
+      const ports = await SerialPort.list();
+      const elm = ports.find((p) => {
+        const id = `${p.path} ${p.manufacturer || ''} ${p.pnpId || ''}`.toLowerCase();
+        return id.includes('elm') || id.includes('obd') || id.includes('rfcomm');
+      });
+      return elm ? elm.path : null;
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  async destroy() {
+    if (this._pendingTimer) {
+      clearTimeout(this._pendingTimer);
+    }
+    if (this._pendingReject) {
+      this._pendingReject(new Error('Driver destroyed'));
+      this._pendingResolve = null;
+      this._pendingReject = null;
+    }
+
+    if (this._port && this._port.isOpen) {
+      return new Promise((resolve) => {
+        this._port.close(() => {
+          this._state = STATES.DISCONNECTED;
+          resolve();
+        });
+      });
+    }
+    this._state = STATES.DISCONNECTED;
+  }
+}
+
+module.exports = { Elm327Driver, STATES, PID_FORMULAS };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,303 @@
+'use strict';
+
+const path = require('path');
+const express = require('express');
+const winston = require('winston');
+const createAudioRouter = require('./api/routes/audio');
+const profilesRouter = require('./api/routes/profiles');
+const PerformanceMonitor = require('./monitoring/performance-monitor');
+const { performanceMiddleware, metricsEndpoint } = require('./middleware/performance-middleware');
+const { HealthCheckService } = require('./services/health-check');
+const { VehicleService } = require('./services/vehicle-service');
+const { NavigationService } = require('./services/navigation-service');
+const { OBDDataProvider } = require('./services/obd-data-provider');
+const { WebSocketService } = require('./services/websocket-service');
+const { ClaudeService } = require('./services/claude-service');
+const createChatRouter = require('./api/routes/chat');
+
+const logger = winston.createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.colorize(),
+    winston.format.printf(({ timestamp, level, message }) => `${timestamp} ${level}: ${message}`),
+  ),
+  transports: [new winston.transports.Console()],
+});
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Middleware
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '..', 'public')));
+
+// Performance monitoring
+const monitor = new PerformanceMonitor();
+app.use(performanceMiddleware(monitor));
+
+// OBD-II data provider
+const obdProvider = new OBDDataProvider({
+  mode: process.env.OBD_MODE || 'auto',
+  serialPort: process.env.OBD_SERIAL_PORT || null,
+  pollIntervalMs: parseInt(process.env.OBD_POLL_INTERVAL, 10) || 500,
+  baudRate: parseInt(process.env.OBD_BAUD_RATE, 10) || 38400,
+});
+
+// Health check service
+const healthCheck = new HealthCheckService();
+
+// Vehicle service
+const vehicleService = new VehicleService();
+healthCheck.registerComponent('vehicle', () => ({
+  status: vehicleService.getVehicleState() ? 'healthy' : 'degraded',
+}));
+
+// Navigation service
+const navigationService = new NavigationService(); // eslint-disable-line no-unused-vars
+healthCheck.registerComponent('navigation', () => ({
+  status: 'healthy',
+}));
+
+// Audio API
+const { router: audioRouter, service: audioService } = createAudioRouter();
+healthCheck.registerComponent('audio', () => ({
+  status: 'healthy',
+  activeSources: audioService.getSources().filter((s) => s.isActive).length,
+}));
+
+// OBD health
+healthCheck.registerComponent('obd', () => ({
+  status: obdProvider.connected ? 'healthy' : 'degraded',
+  mode: obdProvider.activeMode,
+}));
+
+// Claude AI assistant with MCP tool handlers
+const claudeService = new ClaudeService();
+
+claudeService.registerToolHandler('get_vehicle_status', async () => {
+  const vehicle = vehicleService.getVehicleState();
+  const obd = obdProvider.state;
+  return {
+    speed: obd.speed || vehicle.speed || 0,
+    rpm: obd.rpm || vehicle.rpm || 0,
+    gear: vehicle.gear || 'park',
+    coolantTemp: obd.coolantTemp || 0,
+    fuelLevel: obd.fuelLevel || 0,
+    throttle: obd.throttle || 0,
+    engineLoad: obd.engineLoad || 0,
+    batteryVoltage: vehicle.batteryVoltage || 0,
+    ignition: vehicle.ignitionState || (vehicle.ignition ? 'on' : 'off'),
+    parkingBrake: vehicle.parkingBrake || false,
+    obdMode: obdProvider.activeMode,
+  };
+});
+
+claudeService.registerToolHandler('get_diagnostics', async () => {
+  const dtcs = await obdProvider.requestDTCs();
+  return { codes: dtcs, count: dtcs.length, status: dtcs.length === 0 ? 'clear' : 'faults_present' };
+});
+
+claudeService.registerToolHandler('set_audio_source', async (input) => {
+  const result = await audioService.switchSource(input.source, 100);
+  return { switched: true, from: result.previousSource, to: result.currentSource };
+});
+
+claudeService.registerToolHandler('set_volume', async (input) => {
+  const result = audioService.updateControls({ volume: input.volume });
+  return { volume: result.controls.volume };
+});
+
+claudeService.registerToolHandler('set_equalizer', async (input) => {
+  const updates = {};
+  if (input.bass !== undefined) { updates.bass = input.bass; }
+  if (input.treble !== undefined) { updates.treble = input.treble; }
+  if (input.balance !== undefined) { updates.balance = input.balance; }
+  if (input.fade !== undefined) { updates.fade = input.fade; }
+  const result = audioService.updateControls(updates);
+  return result.controls;
+});
+
+claudeService.registerToolHandler('get_audio_status', async () => {
+  const sources = audioService.getSources();
+  const controls = audioService.getControls();
+  const active = sources.find((s) => s.active);
+  return { activeSource: active ? active.name : 'none', controls };
+});
+
+// Navigation tools
+claudeService.registerToolHandler('plan_route', async (input) => {
+  // Simulate route planning with the navigation service
+  const session = navigationService.planRoute({
+    origin: { lat: 33.749, lng: -84.388, name: 'Current Location' },
+    destination: { lat: 33.749 + (Math.random() - 0.5) * 0.1, lng: -84.388 + (Math.random() - 0.5) * 0.1, name: input.destination },
+    preferences: { avoidTolls: input.avoidTolls || false, avoidHighways: input.avoidHighways || false },
+  });
+  return {
+    planned: true,
+    destination: input.destination,
+    sessionId: session.id,
+    distance: session.totalDistance ? `${(session.totalDistance / 1000).toFixed(1)} km` : 'calculating',
+    eta: session.eta || 'calculating',
+    status: session.status,
+  };
+});
+
+claudeService.registerToolHandler('get_navigation_status', async () => {
+  const gps = navigationService.getGpsStatus();
+  return {
+    gpsSignal: gps.signalStatus,
+    hasSignal: gps.hasSignal,
+    position: gps.currentPosition,
+  };
+});
+
+// Profile tools
+claudeService.registerToolHandler('list_profiles', async () => {
+  const { UserProfileService } = require('./services/user-profile-service');
+  const profileService = new UserProfileService();
+  const profiles = profileService.listProfiles();
+  return {
+    profiles: profiles.map((p) => ({ id: p.id, name: p.name, active: p.isActive })),
+    count: profiles.length,
+  };
+});
+
+claudeService.registerToolHandler('create_profile', async (input) => {
+  const { UserProfileService } = require('./services/user-profile-service');
+  const profileService = new UserProfileService();
+  const profile = profileService.createProfile({ name: input.name });
+  return { created: true, id: profile.id, name: profile.name };
+});
+
+claudeService.registerToolHandler('activate_profile', async (input) => {
+  const { UserProfileService } = require('./services/user-profile-service');
+  const profileService = new UserProfileService();
+  const profiles = profileService.listProfiles();
+  const match = profiles.find((p) => p.name.toLowerCase() === input.name.toLowerCase());
+  if (!match) {
+    return { error: `Profile "${input.name}" not found. Available: ${profiles.map((p) => p.name).join(', ') || 'none'}` };
+  }
+  profileService.activateProfile(match.id);
+  return { activated: true, name: match.name, id: match.id };
+});
+
+// System tools
+claudeService.registerToolHandler('get_system_health', async () => {
+  const statuses = healthCheck.getAllStatuses();
+  return statuses;
+});
+
+claudeService.registerToolHandler('get_performance_metrics', async () => {
+  const dashboard = monitor.getDashboardData();
+  return dashboard;
+});
+
+// Media tool — returns data for the dashboard to act on
+claudeService.registerToolHandler('play_media', async (input) => {
+  const { action, query } = input;
+  const serviceUrls = {
+    youtube: 'https://m.youtube.com',
+    primevideo: 'https://www.primevideo.com',
+    netflix: 'https://www.netflix.com',
+    disneyplus: 'https://www.disneyplus.com',
+    hbomax: 'https://play.max.com',
+    spotify: 'https://open.spotify.com',
+  };
+
+  if (action === 'youtube_search' && query) {
+    return { action: 'open_url', url: `https://m.youtube.com/results?search_query=${encodeURIComponent(query)}`, label: `YouTube: ${query}` };
+  }
+  if (action === 'youtube_video' && query) {
+    // Extract video ID from various YouTube URL formats
+    const match = query.match(/(?:v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    if (match) {
+      return { action: 'embed_youtube', videoId: match[1], label: 'YouTube Video' };
+    }
+    return { action: 'open_url', url: query, label: 'YouTube Video' };
+  }
+  if (action === 'open_service' && query) {
+    const key = query.toLowerCase().replace(/[\s_-]/g, '');
+    const url = serviceUrls[key];
+    if (url) {
+      return { action: 'open_url', url, label: query };
+    }
+    return { error: `Unknown service: ${query}. Available: ${Object.keys(serviceUrls).join(', ')}` };
+  }
+  if (action === 'open_url' && query) {
+    return { action: 'open_url', url: query, label: 'Media' };
+  }
+  if (action === 'close') {
+    return { action: 'close_media', label: 'Closed media player' };
+  }
+  return { error: 'Invalid media action' };
+});
+
+const chatRouter = createChatRouter(claudeService);
+
+// Routes
+app.use('/api/v1/audio', audioRouter);
+app.use('/api/v1/profiles', profilesRouter);
+app.use('/api/v1/chat', chatRouter);
+
+// System endpoints
+app.get('/api/v1/health', (_req, res) => {
+  const statuses = healthCheck.getAllStatuses();
+  res.json({
+    timestamp: new Date().toISOString(),
+    components: statuses,
+  });
+});
+
+app.get('/api/v1/metrics', metricsEndpoint(monitor));
+
+app.get('/api/v1/vehicle/state', (_req, res) => {
+  const vehicleState = vehicleService.getVehicleState();
+  const obdState = obdProvider.state;
+  res.json({
+    timestamp: new Date().toISOString(),
+    success: true,
+    data: { ...vehicleState, ...obdState },
+  });
+});
+
+app.get('/api/v1/vehicle/obd', (_req, res) => {
+  res.json({
+    timestamp: new Date().toISOString(),
+    success: true,
+    data: obdProvider.getConnectionStatus(),
+  });
+});
+
+app.get('/api/v1/navigation/status', (_req, res) => {
+  res.json({
+    timestamp: new Date().toISOString(),
+    success: true,
+    data: navigationService.getGpsStatus(),
+  });
+});
+
+// Start server
+if (require.main === module) {
+  vehicleService.start();
+  obdProvider.start().then(() => {
+    logger.info(`OBD mode: ${obdProvider.activeMode}`);
+  }).catch((err) => {
+    logger.warn(`OBD start failed: ${err.message}, continuing without OBD`);
+  });
+
+  const server = app.listen(PORT, () => {
+    logger.info(`CarConnect Pro started on port ${PORT}`);
+    logger.info(`Dashboard:  http://localhost:${PORT}`);
+    logger.info(`WebSocket:  ws://localhost:${PORT}`);
+    logger.info(`OBD Mode:   ${process.env.OBD_MODE || 'auto'}`);
+  });
+
+  const _wsService = new WebSocketService(server, { // eslint-disable-line no-unused-vars
+    vehicleService,
+    audioService,
+    obdProvider,
+  });
+}
+
+module.exports = app;

--- a/src/services/audio-service.js
+++ b/src/services/audio-service.js
@@ -26,6 +26,28 @@ class AudioService {
       bass: 0,
       treble: 0,
     };
+    this._listeners = new Map();
+  }
+
+  on(event, fn) {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event).push(fn);
+  }
+
+  off(event, fn) {
+    const fns = this._listeners.get(event);
+    if (fns) {
+      this._listeners.set(event, fns.filter((f) => f !== fn));
+    }
+  }
+
+  _emit(event, data) {
+    const fns = this._listeners.get(event) || [];
+    for (const fn of fns) {
+      fn(data);
+    }
   }
 
   getSources() {
@@ -64,13 +86,16 @@ class AudioService {
 
     const elapsed = Date.now() - startTime;
 
-    return {
+    const result = {
       previousSource: previousSourceId,
       currentSource: this.activeSourceId,
       fadeTime: simulatedDelay,
       switchTime: elapsed,
       transactionId: uuidv4(),
     };
+
+    this._emit('audioSourceChange', result);
+    return result;
   }
 
   getControls() {
@@ -87,10 +112,13 @@ class AudioService {
       }
     }
 
-    return {
+    const result = {
       controls: { ...this.controls },
       updatedFields,
     };
+
+    this._emit('audioControlsChange', result);
+    return result;
   }
 
   setSourceConnected(sourceId, connected) {

--- a/src/services/claude-service.js
+++ b/src/services/claude-service.js
@@ -1,0 +1,289 @@
+'use strict';
+
+const Anthropic = require('@anthropic-ai/sdk');
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json(),
+  ),
+  defaultMeta: { service: 'claude-service' },
+  transports: [new winston.transports.Console({ silent: process.env.NODE_ENV === 'test' })],
+});
+
+const SYSTEM_PROMPT = `You are the CarConnect Pro in-vehicle AI assistant for a 2013 Hyundai Elantra GT. You can:
+- Check vehicle status: speed, RPM, fuel, coolant, battery, diagnostics
+- Control audio: source, volume, bass, treble, balance, fade
+- Navigation: plan routes, check GPS status
+- Manage user profiles: list, create, switch
+- Monitor system health and performance
+- Play media: search YouTube, open streaming services (Prime Video, Netflix, etc.), play videos
+- Have friendly conversations about anything
+
+Keep responses SHORT — the driver is listening via voice. 1-3 sentences max. Be warm and natural.
+
+ALWAYS use tools when relevant — don't guess vehicle data, use get_vehicle_status. Don't guess audio settings, use get_audio_status.
+When the user asks to play something, watch a video, or open a streaming service, use the play_media tool.
+When you change settings, briefly confirm what you did.`;
+
+const TOOLS = [
+  // --- Vehicle ---
+  {
+    name: 'get_vehicle_status',
+    description: 'Get the current vehicle state including speed, RPM, gear, coolant temp, fuel level, battery voltage, throttle position, and engine load. Use this whenever the user asks about their car.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_diagnostics',
+    description: 'Read diagnostic trouble codes (DTCs) from the vehicle. Use when the user asks about check engine light, error codes, or vehicle problems.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  // --- Audio ---
+  {
+    name: 'set_audio_source',
+    description: 'Switch the active audio source.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        source: {
+          type: 'string',
+          enum: ['radio', 'bluetooth', 'usb', 'aux', 'android_auto', 'apple_carplay'],
+          description: 'The audio source to switch to',
+        },
+      },
+      required: ['source'],
+    },
+  },
+  {
+    name: 'set_volume',
+    description: 'Set the audio volume level.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        volume: { type: 'number', minimum: 0, maximum: 100, description: 'Volume level 0-100' },
+      },
+      required: ['volume'],
+    },
+  },
+  {
+    name: 'set_equalizer',
+    description: 'Adjust audio equalizer settings: bass, treble, balance, or fade.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        bass: { type: 'number', minimum: -10, maximum: 10, description: 'Bass level -10 to 10' },
+        treble: { type: 'number', minimum: -10, maximum: 10, description: 'Treble level -10 to 10' },
+        balance: { type: 'number', minimum: -100, maximum: 100, description: 'Balance L/R -100 to 100' },
+        fade: { type: 'number', minimum: -100, maximum: 100, description: 'Fade front/rear -100 to 100' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_audio_status',
+    description: 'Get current audio source and control settings.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  // --- Navigation ---
+  {
+    name: 'plan_route',
+    description: 'Plan a navigation route to a destination. Use when the user wants directions or wants to go somewhere.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        destination: { type: 'string', description: 'Destination name or address' },
+        avoidTolls: { type: 'boolean', description: 'Avoid toll roads' },
+        avoidHighways: { type: 'boolean', description: 'Avoid highways' },
+      },
+      required: ['destination'],
+    },
+  },
+  {
+    name: 'get_navigation_status',
+    description: 'Get current GPS/navigation status including position, signal, and any active route.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  // --- Profiles ---
+  {
+    name: 'list_profiles',
+    description: 'List all user profiles. Use when the user asks about profiles or who is logged in.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'create_profile',
+    description: 'Create a new user profile with a name.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name for the new profile' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'activate_profile',
+    description: 'Switch to a different user profile by name.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name of the profile to activate' },
+      },
+      required: ['name'],
+    },
+  },
+  // --- System ---
+  {
+    name: 'get_system_health',
+    description: 'Get health status of all system components (vehicle, audio, navigation, OBD).',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'get_performance_metrics',
+    description: 'Get system performance metrics including response times and resource usage.',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  // --- Media ---
+  {
+    name: 'play_media',
+    description: 'Open a video or streaming service on the infotainment display. Use when the user wants to watch YouTube, Prime Video, Netflix, or any video URL. Returns a command for the dashboard to execute.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['youtube_search', 'youtube_video', 'open_url', 'open_service', 'close'],
+          description: 'The media action to perform',
+        },
+        query: { type: 'string', description: 'Search query for YouTube, video URL, or service name (youtube/primevideo/netflix/disneyplus/hbomax/spotify)' },
+      },
+      required: ['action'],
+    },
+  },
+];
+
+class ClaudeService {
+  constructor(options = {}) {
+    this._apiKey = options.apiKey || process.env.ANTHROPIC_API_KEY || null;
+    this._model = options.model || 'claude-sonnet-4-20250514';
+    this._client = null;
+    this._conversations = new Map();
+    this._maxHistory = 30;
+    this._toolHandlers = new Map();
+
+    if (this._apiKey) {
+      this._client = new Anthropic({ apiKey: this._apiKey });
+      logger.info('Claude service initialized with tool use');
+    } else {
+      logger.warn('No ANTHROPIC_API_KEY set — Claude chat disabled');
+    }
+  }
+
+  get available() {
+    return this._client !== null;
+  }
+
+  registerToolHandler(name, handler) {
+    this._toolHandlers.set(name, handler);
+  }
+
+  async chat(sessionId, userMessage) {
+    if (!this._client) {
+      throw new Error('Claude service not configured — set ANTHROPIC_API_KEY');
+    }
+
+    if (!this._conversations.has(sessionId)) {
+      this._conversations.set(sessionId, []);
+    }
+
+    const history = this._conversations.get(sessionId);
+
+    history.push({ role: 'user', content: userMessage });
+
+    while (history.length > this._maxHistory) {
+      history.shift();
+    }
+
+    try {
+      // Agentic loop: keep calling Claude until we get a final text response
+      let response = await this._client.messages.create({
+        model: this._model,
+        max_tokens: 1024,
+        system: SYSTEM_PROMPT,
+        tools: TOOLS,
+        messages: history,
+      });
+
+      const toolsUsed = [];
+      const mediaCommands = [];
+
+      // Process tool use in a loop
+      while (response.stop_reason === 'tool_use') {
+        const assistantContent = response.content;
+        history.push({ role: 'assistant', content: assistantContent });
+
+        const toolResults = [];
+        for (const block of assistantContent) {
+          if (block.type === 'tool_use') {
+            const result = await this._executeTool(block.name, block.input);
+            toolsUsed.push(block.name);
+
+            // Capture media commands to forward to dashboard
+            if (block.name === 'play_media' && result && result.action) {
+              mediaCommands.push(result);
+            }
+
+            toolResults.push({
+              type: 'tool_result',
+              tool_use_id: block.id,
+              content: JSON.stringify(result),
+            });
+            logger.info('Tool executed', { tool: block.name, input: block.input });
+          }
+        }
+
+        history.push({ role: 'user', content: toolResults });
+
+        response = await this._client.messages.create({
+          model: this._model,
+          max_tokens: 1024,
+          system: SYSTEM_PROMPT,
+          tools: TOOLS,
+          messages: history,
+        });
+      }
+
+      // Extract final text
+      const textBlocks = response.content.filter((b) => b.type === 'text');
+      const assistantMessage = textBlocks.map((b) => b.text).join('\n');
+
+      history.push({ role: 'assistant', content: response.content });
+
+      return { reply: assistantMessage, toolsUsed, mediaCommands };
+    } catch (err) {
+      logger.error('Claude API error', { error: err.message });
+      history.pop();
+      throw err;
+    }
+  }
+
+  async _executeTool(name, input) {
+    const handler = this._toolHandlers.get(name);
+    if (!handler) {
+      return { error: `No handler registered for tool: ${name}` };
+    }
+
+    try {
+      return await handler(input);
+    } catch (err) {
+      return { error: err.message };
+    }
+  }
+
+  clearConversation(sessionId) {
+    this._conversations.delete(sessionId);
+  }
+}
+
+module.exports = { ClaudeService };

--- a/src/services/obd-data-provider.js
+++ b/src/services/obd-data-provider.js
@@ -1,0 +1,274 @@
+'use strict';
+
+const winston = require('winston');
+const { Elm327Driver } = require('../drivers/elm327-driver');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json(),
+  ),
+  defaultMeta: { service: 'obd-data-provider' },
+  transports: [new winston.transports.Console({ silent: process.env.NODE_ENV === 'test' })],
+});
+
+const MODES = {
+  AUTO: 'auto',
+  ELM327: 'elm327',
+  SIMULATION: 'simulation',
+};
+
+const HIGH_PRIORITY_PIDS = ['0C', '0D']; // RPM, Speed
+const LOW_PRIORITY_PIDS = ['05', '2F', '11', '04']; // Coolant, Fuel, Throttle, Load
+
+class OBDDataProvider {
+  constructor(options = {}) {
+    this._mode = options.mode || MODES.AUTO;
+    this._serialPort = options.serialPort || null;
+    this._pollInterval = options.pollIntervalMs || 500;
+    this._baudRate = options.baudRate || 38400;
+    this._driver = null;
+    this._pollTimer = null;
+    this._lowPriorityIndex = 0;
+    this._started = false;
+    this._activeMode = null;
+    this._listeners = new Map();
+
+    this._state = {
+      speed: 0,
+      rpm: 0,
+      coolantTemp: 0,
+      fuelLevel: 0,
+      throttle: 0,
+      engineLoad: 0,
+    };
+
+    // Simulation state
+    this._simTime = 0;
+    this._simDriving = false;
+    this._simAccelerating = false;
+  }
+
+  get state() {
+    return { ...this._state };
+  }
+
+  get activeMode() {
+    return this._activeMode;
+  }
+
+  get connected() {
+    return this._started && (this._activeMode === MODES.ELM327 || this._activeMode === MODES.SIMULATION);
+  }
+
+  on(event, fn) {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event).push(fn);
+  }
+
+  off(event, fn) {
+    const fns = this._listeners.get(event);
+    if (fns) {
+      this._listeners.set(event, fns.filter((f) => f !== fn));
+    }
+  }
+
+  _emit(event, data) {
+    const fns = this._listeners.get(event) || [];
+    for (const fn of fns) {
+      try {
+        fn(data);
+      } catch (e) {
+        logger.error('Event listener error', { event, error: e.message });
+      }
+    }
+  }
+
+  async start() {
+    if (this._started) {
+      return;
+    }
+
+    if (this._mode === MODES.ELM327 || this._mode === MODES.AUTO) {
+      try {
+        this._driver = new Elm327Driver({
+          serialPort: this._serialPort,
+          baudRate: this._baudRate,
+        });
+        await this._driver.connect();
+        this._activeMode = MODES.ELM327;
+        logger.info('Connected to ELM327 OBD-II dongle');
+      } catch (err) {
+        logger.warn('ELM327 connection failed', { error: err.message });
+        if (this._mode === MODES.ELM327) {
+          throw err;
+        }
+        // Auto mode: fall back to simulation
+        this._driver = null;
+        this._activeMode = MODES.SIMULATION;
+        logger.info('Falling back to OBD simulation mode');
+      }
+    } else {
+      this._activeMode = MODES.SIMULATION;
+      logger.info('Starting in OBD simulation mode');
+    }
+
+    this._started = true;
+    this._emit('modeChange', this._activeMode);
+    this._startPolling();
+  }
+
+  async stop() {
+    this._started = false;
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+    if (this._driver) {
+      await this._driver.destroy();
+      this._driver = null;
+    }
+    this._activeMode = null;
+  }
+
+  async requestDTCs() {
+    if (this._activeMode === MODES.ELM327 && this._driver) {
+      return this._driver.requestDTCs();
+    }
+    // Simulation: return empty
+    return [];
+  }
+
+  getConnectionStatus() {
+    return {
+      mode: this._activeMode,
+      configured: this._mode,
+      connected: this.connected,
+      serialPort: this._serialPort,
+    };
+  }
+
+  _startPolling() {
+    this._pollTimer = setInterval(() => {
+      if (this._activeMode === MODES.ELM327) {
+        this._pollELM327().catch((err) => {
+          logger.error('ELM327 poll error', { error: err.message });
+        });
+      } else {
+        this._pollSimulation();
+      }
+    }, this._pollInterval);
+  }
+
+  async _pollELM327() {
+    // High priority: speed + RPM every cycle
+    for (const pid of HIGH_PRIORITY_PIDS) {
+      try {
+        const result = await this._driver.requestPID(pid);
+        if (result) {
+          this._updateValue(result.name, result.value);
+        }
+      } catch (_err) {
+        // Skip this PID on error
+      }
+    }
+
+    // Low priority: one per cycle, rotating
+    const lowPid = LOW_PRIORITY_PIDS[this._lowPriorityIndex];
+    this._lowPriorityIndex = (this._lowPriorityIndex + 1) % LOW_PRIORITY_PIDS.length;
+
+    try {
+      const result = await this._driver.requestPID(lowPid);
+      if (result) {
+        this._updateValue(result.name, result.value);
+      }
+    } catch (_err) {
+      // Skip
+    }
+
+    this._emit('vehicleDataUpdate', this.state);
+  }
+
+  _pollSimulation() {
+    this._simTime += this._pollInterval / 1000;
+
+    // Simulate driving pattern: idle → accelerate → cruise → decelerate → idle
+    const cycle = this._simTime % 60; // 60-second cycle
+
+    let targetRpm, targetSpeed;
+
+    if (cycle < 5) {
+      // Idle
+      targetRpm = 780 + Math.sin(this._simTime * 2) * 30;
+      targetSpeed = 0;
+    } else if (cycle < 15) {
+      // Accelerating
+      const t = (cycle - 5) / 10;
+      targetRpm = 780 + t * 3200;
+      targetSpeed = t * 80;
+    } else if (cycle < 35) {
+      // Cruising
+      targetRpm = 2200 + Math.sin(this._simTime * 0.5) * 200;
+      targetSpeed = 60 + Math.sin(this._simTime * 0.3) * 15;
+    } else if (cycle < 45) {
+      // Decelerating
+      const t = 1 - (cycle - 35) / 10;
+      targetRpm = 780 + t * 1400;
+      targetSpeed = t * 60;
+    } else {
+      // Idle
+      targetRpm = 780 + Math.sin(this._simTime * 2) * 30;
+      targetSpeed = 0;
+    }
+
+    // Smooth transitions
+    this._state.rpm = this._lerp(this._state.rpm, targetRpm, 0.15);
+    this._state.speed = this._lerp(this._state.speed, Math.max(0, targetSpeed), 0.12);
+
+    // Slow-changing values
+    this._state.coolantTemp = this._lerp(this._state.coolantTemp,
+      85 + Math.sin(this._simTime * 0.05) * 10, 0.02);
+    this._state.fuelLevel = Math.max(0, 72 - this._simTime * 0.01);
+    this._state.throttle = this._state.speed > 0
+      ? 15 + (this._state.rpm - 780) / 3200 * 75
+      : 0;
+    this._state.engineLoad = this._state.speed > 0
+      ? 20 + (this._state.rpm / 4000) * 60
+      : 12;
+
+    // Emit individual events
+    this._emit('speedChange', { speed: Math.round(this._state.speed) });
+    this._emit('rpmChange', { rpm: Math.round(this._state.rpm) });
+    this._emit('coolantTempChange', { coolantTemp: Math.round(this._state.coolantTemp) });
+    this._emit('fuelLevelChange', { fuelLevel: Math.round(this._state.fuelLevel) });
+    this._emit('throttleChange', { throttle: Math.round(this._state.throttle) });
+    this._emit('engineLoadChange', { engineLoad: Math.round(this._state.engineLoad) });
+
+    // Consolidated update
+    this._emit('vehicleDataUpdate', {
+      speed: Math.round(this._state.speed),
+      rpm: Math.round(this._state.rpm),
+      coolantTemp: Math.round(this._state.coolantTemp),
+      fuelLevel: Math.round(this._state.fuelLevel),
+      throttle: Math.round(this._state.throttle),
+      engineLoad: Math.round(this._state.engineLoad),
+    });
+  }
+
+  _updateValue(name, value) {
+    const prev = this._state[name];
+    this._state[name] = value;
+    if (prev !== value) {
+      this._emit(`${name}Change`, { [name]: value });
+    }
+  }
+
+  _lerp(current, target, factor) {
+    return current + (target - current) * factor;
+  }
+}
+
+module.exports = { OBDDataProvider, MODES };

--- a/src/services/websocket-service.js
+++ b/src/services/websocket-service.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const WebSocket = require('ws');
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json(),
+  ),
+  defaultMeta: { service: 'websocket-service' },
+  transports: [new winston.transports.Console({ silent: process.env.NODE_ENV === 'test' })],
+});
+
+const HEARTBEAT_INTERVAL = 30000;
+
+class WebSocketService {
+  constructor(server, options = {}) {
+    this._vehicleService = options.vehicleService || null;
+    this._audioService = options.audioService || null;
+    this._obdProvider = options.obdProvider || null;
+    this._clients = new Set();
+
+    this._wss = new WebSocket.Server({ server });
+    this._wss.on('connection', (ws) => this._onConnection(ws));
+
+    this._heartbeatTimer = setInterval(() => this._heartbeat(), HEARTBEAT_INTERVAL);
+
+    this._setupEventBridges();
+    logger.info('WebSocket server started');
+  }
+
+  _onConnection(ws) {
+    ws.isAlive = true;
+    ws.on('pong', () => { ws.isAlive = true; });
+    ws.on('close', () => this._clients.delete(ws));
+    ws.on('error', () => this._clients.delete(ws));
+
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(data);
+        this._handleClientMessage(ws, msg);
+      } catch (_e) {
+        // Ignore malformed messages
+      }
+    });
+
+    this._clients.add(ws);
+    logger.info('Client connected', { clients: this._clients.size });
+
+    // Send initial state snapshot
+    this._sendInitialState(ws);
+  }
+
+  _sendInitialState(ws) {
+    const snapshot = { type: 'init', timestamp: new Date().toISOString(), data: {} };
+
+    if (this._vehicleService) {
+      snapshot.data.vehicle = this._vehicleService.getVehicleState();
+    }
+
+    if (this._obdProvider) {
+      snapshot.data.obd = this._obdProvider.state;
+      snapshot.data.obdConnection = this._obdProvider.getConnectionStatus();
+    }
+
+    if (this._audioService) {
+      snapshot.data.audio = {
+        sources: this._audioService.getSources(),
+        controls: this._audioService.getControls(),
+      };
+    }
+
+    this._send(ws, snapshot);
+  }
+
+  _handleClientMessage(ws, msg) {
+    if (msg.type === 'requestDTCs' && this._obdProvider) {
+      this._obdProvider.requestDTCs().then((dtcs) => {
+        this._send(ws, { type: 'dtcResponse', data: dtcs, timestamp: new Date().toISOString() });
+      });
+    }
+  }
+
+  _setupEventBridges() {
+    if (this._obdProvider) {
+      this._obdProvider.on('vehicleDataUpdate', (data) => {
+        this._broadcast({ type: 'vehicleData', data, timestamp: new Date().toISOString() });
+      });
+
+      this._obdProvider.on('modeChange', (mode) => {
+        this._broadcast({ type: 'obdMode', data: { mode }, timestamp: new Date().toISOString() });
+      });
+    }
+
+    if (this._audioService && this._audioService.on) {
+      this._audioService.on('audioSourceChange', (data) => {
+        this._broadcast({ type: 'audioState', data, timestamp: new Date().toISOString() });
+      });
+
+      this._audioService.on('audioControlsChange', (data) => {
+        this._broadcast({ type: 'audioControls', data, timestamp: new Date().toISOString() });
+      });
+    }
+  }
+
+  _broadcast(msg) {
+    const payload = JSON.stringify(msg);
+    for (const client of this._clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(payload);
+      }
+    }
+  }
+
+  _send(ws, msg) {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  }
+
+  _heartbeat() {
+    for (const ws of this._clients) {
+      if (!ws.isAlive) {
+        ws.terminate();
+        this._clients.delete(ws);
+        continue;
+      }
+      ws.isAlive = false;
+      ws.ping();
+    }
+  }
+
+  getClientCount() {
+    return this._clients.size;
+  }
+
+  shutdown() {
+    clearInterval(this._heartbeatTimer);
+    for (const client of this._clients) {
+      client.terminate();
+    }
+    this._clients.clear();
+    this._wss.close();
+  }
+}
+
+module.exports = { WebSocketService };


### PR DESCRIPTION
## Summary

- **ELM327 OBD-II driver** (`src/drivers/elm327-driver.js`) — connects to a $15 Bluetooth dongle to read real vehicle data (speed, RPM, coolant, fuel, throttle, engine load, DTCs). Auto-detects serial port, falls back to realistic simulation when no dongle is connected.

- **WebSocket real-time streaming** (`src/services/websocket-service.js`) — pushes live vehicle and audio state to the browser at 2Hz instead of REST polling. Auto-reconnect with exponential backoff.

- **Web dashboard** (`public/index.html`) — dark automotive-themed single-page UI with live speedometer/tachometer gauges, vehicle info cards, audio source switching, volume/EQ sliders, system health, and clock. Touch-optimized for tablet mounting in the car.

- **Claude AI assistant** (`src/services/claude-service.js`) — 13 MCP tools for hands-free car control:
  - Vehicle: `get_vehicle_status`, `get_diagnostics`
  - Audio: `set_audio_source`, `set_volume`, `set_equalizer`, `get_audio_status`
  - Navigation: `plan_route`, `get_navigation_status`
  - Profiles: `list_profiles`, `create_profile`, `activate_profile`
  - System: `get_system_health`, `get_performance_metrics`
  - Media: `play_media` (YouTube, Prime Video, Netflix, Disney+, Max, Spotify)

- **Voice conversation mode** — mic button for push-to-talk, loop button for continuous hands-free conversation (mic auto-reopens after Claude finishes speaking). Uses Web Speech API for recognition and synthesis.

- **Media player** — embedded streaming panel with service quick-buttons, YouTube search/embed, and URL bar. Claude can open media via voice ("play lo-fi beats on YouTube", "open Netflix").

## Test plan
- [x] `npm test` — 677 tests passing
- [x] `npm run lint` — 0 errors
- [x] Server starts in simulation mode with `npm start`
- [x] Dashboard loads at `http://localhost:3000` with live gauges
- [x] Audio controls work (source switching, volume/EQ sliders)
- [x] WebSocket connects and streams real-time data
- [ ] Claude chat works with `ANTHROPIC_API_KEY` set
- [ ] ELM327 connects with `OBD_SERIAL_PORT` set
- [ ] Voice input/output and conversation mode work in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)